### PR TITLE
Fix Linux python2 compatibility

### DIFF
--- a/SSDTTime.py
+++ b/SSDTTime.py
@@ -682,7 +682,7 @@ DefinitionBlock ("", "SSDT", 2, "hack", "HPET", 0x00000000)
         print("1. FixHPET    - Patch out IRQ Conflicts")
         print("2. FakeEC     - OS-aware Fake EC")
         print("3. PluginType - Sets plugin-type = 1 on CPU0/PR00")
-        if sys.platform == "linux" or sys.platform == "win32":
+        if sys.platform.startswith('linux') or sys.platform == "win32":
             print("4. Dump DSDT  - Automatically dump the system DSDT")
         print("")
         print("D. Select DSDT or origin folder")
@@ -703,7 +703,7 @@ DefinitionBlock ("", "SSDT", 2, "hack", "HPET", 0x00000000)
         elif menu == "3":
             self.plugin_type()
         elif menu == "4":
-            if sys.platform == "linux" or sys.platform == "win32":
+            if sys.platform.startswith('linux') or sys.platform == "win32":
                 self.dsdt = self.d.dump_dsdt(self.output)
             else:
                 return

--- a/Scripts/dsdt.py
+++ b/Scripts/dsdt.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # 0.0.0
-import os, tempfile, shutil, plistlib, sys, binascii, zipfile
+import getpass, os, tempfile, shutil, plistlib, sys, binascii, zipfile
 sys.path.append(os.path.abspath(os.path.dirname(os.path.realpath(__file__))))
 import run, downloader, utils
 
@@ -90,7 +90,7 @@ class DSDT:
             try:
                 if sys.platform == "darwin":
                     self._download_and_extract(temp,self.iasl_url_macOS)
-                elif sys.platform == "linux":
+                elif sys.platform.startswith('linux'):
                     self._download_and_extract(temp,self.iasl_url_linux)
                 elif sys.platform == "win32":
                     self._download_and_extract(temp,self.iasl_url_windows)
@@ -134,7 +134,7 @@ class DSDT:
         self.u.head("Dumping DSDT")
         print("")
         res = self.check_output(output)
-        if sys.platform == "linux":
+        if sys.platform.startswith('linux'):
             print("Checking if DSDT exists")
             e = "/sys/firmware/acpi/tables/DSDT"
             dsdt_path = os.path.join(res,"DSDT.aml")


### PR DESCRIPTION
sys.platform returns `linux2` under Python2
With this change dumping the DSDT should work with both python2 and python3