### PR TITLE
Update relative import to be python 3 compatible

### DIFF
--- a/Scripts/dsdt.py
+++ b/Scripts/dsdt.py
@@ -2,7 +2,7 @@
 # 0.0.0
 import os, tempfile, shutil, plistlib, sys, binascii, zipfile, getpass
 sys.path.append(os.path.abspath(os.path.dirname(os.path.realpath(__file__))))
-import run, downloader, utils
+from . import run, downloader, utils
 
 class DSDT:
     def __init__(self, **kwargs):

--- a/Scripts/reveal.py
+++ b/Scripts/reveal.py
@@ -1,6 +1,6 @@
 import sys, os
 sys.path.append(os.path.abspath(os.path.dirname(os.path.realpath(__file__))))
-import run
+from . import run
 
 class Reveal:
 


### PR DESCRIPTION
In reveal.py and dsdt.py, use "from . import" to do relative import
from the current directory. Otherwise it could incurr
"module 'run' has no attribute 'Run'"  error for python 3.