### PR TITLE
Fix "name 'downloader' is not defined"

### DIFF
--- a/SSDTTime.py
+++ b/SSDTTime.py
@@ -1,4 +1,4 @@
-from Scripts import *
+from Scripts import downloader, utils, run, reveal, dsdt, plist
 import getpass, os, tempfile, shutil, plistlib, sys, binascii, zipfile, re, string
 
 class SSDT:


### PR DESCRIPTION
Fix import for Python 3.9.2

- import * doesn't work and results in "name 'downloader' is not defined"