### PR TITLE
Update function to download Windows Binary Tools due to Intel changes

### DIFF
--- a/Scripts/dsdt.py
+++ b/Scripts/dsdt.py
@@ -246,17 +246,8 @@ class DSDT:
         try:
             source = self.dl.get_string(self.acpi_binary_tools, progress=False, headers=self.h)
             for line in source.split("\n"):
-                # <a href="/content/www/us/en/download/774881/acpi-component-architecture-downloads-windows-binary-tools.html">iASL Compiler and Windows ACPI Tools
-                if "windows-binary-tools" in line and ">iasl compiler and windows acpi tools" in line.lower():
-                    # Try to scrape and load the next page
-                    try:
-                        dl_page_url = "https://www.intel.com" + line.split('<a href="')[1].split('"')[0]
-                        dl_page_source = self.dl.get_string(dl_page_url, progress=False, headers=self.h)
-                        for line in dl_page_source.split("\n"):
-                            if '"download-button"' in line: # Should have the right line
-                                return line.split('data-href="')[1].split('"')[0]
-                    except:
-                        return None
+                if "href" in line and ">iasl compiler and windows acpi tools" in line.lower():
+                    return line.split('<a href="')[1].split('"')[0]
         except: pass
         return None
     


### PR DESCRIPTION
The download link for Windows Binary Tools has been directly pointed to the GitHub link.